### PR TITLE
Use pip to install pycompilation and pycodeexport

### DIFF
--- a/scripts/setup_conda_testenv.sh
+++ b/scripts/setup_conda_testenv.sh
@@ -2,6 +2,6 @@
 
 PY_VERSION=$1
 ENV_NAME=$2
-conda create --quiet -n $ENV_NAME python=${PY_VERSION} cython=0.21 pip sphinx pytest numpydoc future pycompilation pycodeexport
+conda create --quiet -n $ENV_NAME python=${PY_VERSION} cython=0.21 pip sphinx pytest numpydoc future
 source activate $ENV_NAME
-pip install --quiet argh pytest-pep8 pytest-cov python-coveralls sphinx_rtd_theme https://github.com/sympy/sympy/archive/master.zip
+pip install --quiet argh pytest-pep8 pytest-cov python-coveralls sphinx_rtd_theme pycompilation pycodeexport https://github.com/sympy/sympy/archive/master.zip


### PR DESCRIPTION
@asmeurer: this should allow Mac OS X to reproduce the intermittently failing build.
